### PR TITLE
nvme/023: use character device for nvme smart-log command

### DIFF
--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -24,16 +24,16 @@ test() {
 
 	_setup_nvmet
 
-	local ns
+	local nvmedev
 
 	_nvmet_target_setup
 
 	_nvme_connect_subsys
 
-	ns=$(_find_nvme_ns "${def_subsys_uuid}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 
-	if ! nvme smart-log "/dev/${ns}" >> "$FULL" 2>&1; then
-		echo "ERROR: smart-log bdev-ns failed"
+	if ! nvme smart-log "/dev/${nvmedev}" >> "$FULL" 2>&1; then
+		echo "ERROR: smart-log /dev/${nvmedev} failed"
 	fi
 
 	_nvme_disconnect_subsys >> "$FULL" 2>&1


### PR DESCRIPTION
The nvme-cli v2.12 changed to use the character device for nvme smart-log command, update nvme/023 to use char device to avoid the case failure.

$ nvme smart-log /dev/nvme0n1
smart log: No such device or address
$ nvme smart-log /dev/nvme0
Smart Log for NVME device:nvme0 namespace-id:ffffffff critical_warning			: 0
temperature				: -459 °F (0 K)
available_spare				: 0%
available_spare_threshold		: 0%
percentage_used				: 0%
endurance group critical warning summary: 0
Data Units Read				: 20 (10.24 MB)
Data Units Written			: 0 (0.00 B)
host_read_commands			: 142
host_write_commands			: 0
controller_busy_time			: 0
power_cycles				: 0
power_on_hours				: 0
unsafe_shutdowns			: 0
media_errors				: 0
num_err_log_entries			: 0
Warning Temperature Time		: 0
Critical Composite Temperature Time	: 0
Thermal Management T1 Trans Count	: 0
Thermal Management T2 Trans Count	: 0
Thermal Management T1 Total Time	: 0
Thermal Management T2 Total Time	: 0

Link: https://github.com/osandov/blktests/issues/172