### PR TITLE
common/nvme: fix nvme json support check in _have_nvme_cli_with_json_support

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -65,7 +65,7 @@ _require_nvme_trtype_is_fabrics() {
 _have_nvme_cli_with_json_support() {
 	_have_program nvme || return $?
 
-	if ! nvme list --output-format=json &> /dev/null; then
+	if ! nvme list --help 2>&1 | grep -q json; then
 		SKIP_REASONS+=("nvme-cli does not support json output format")
 		return 1
 	fi


### PR DESCRIPTION

$ nvme list
Failed to scan topology: No such file or directory $ nvme list -o json
{
  "error":"Failed to scan topology: No such file or directory"
}
$ ./check nvme/006
nvme/***                                                     [not run]
    nvme-cli does not support json output format
$ modprobe nvme-loop
$ ./check nvme/006
nvme/006 (tr=loop bd=device) (create an NVMeOF target)       [passed]
    runtime    ...  0.141s
nvme/006 (tr=loop bd=file) (create an NVMeOF target)         [passed]
    runtime    ...  0.117s

Link: https://github.com/linux-blktests/blktests/issues/177
Suggested-by: Daniel Wagner <dwagner@suse.de>