### PR TITLE
loop/011: use lazy umount for tmpfs

### DIFF
--- a/tests/loop/011
+++ b/tests/loop/011
@@ -33,7 +33,7 @@ test() {
 	errors=$(_dmesg_since_test_start | grep -c "operation not supported error, dev .*WRITE_ZEROES")
 
 	losetup --detach "$loop_dev"
-	umount "$TMPDIR/tmpfs"
+	umount --lazy "$TMPDIR/tmpfs"
 
 	echo "Found $errors error(s) in dmesg"
 


### PR DESCRIPTION
CKI reported random loop/011 failure, fix it by using lazy umount for tmpfs.

$ ./check loop/011
loop/011 (Make sure unsupported backing file fallocate does not fill dmesg with errors) loop/011 (Make sure unsupported backing file fallocate does not fill dmesg with errors) [failed]
    runtime  0.148s  ...  0.145sults/tmpdir.loop.011.QiG/tmpfs': Device or resource busy
    --- tests/loop/011.out	2025-06-09 03:49:23.017287762 +0000
    +++ /root/blk/results/nodev/loop/011.out.bad	2025-06-09 04:26:22.645147858 +0000
    @@ -1,3 +1,4 @@
     Running loop/011
    +umount: /root/blk/results/tmpdir.loop.011.QiG/tmpfs: target is busy.
     Found 1 error(s) in dmesg
     Test complete
$ mount | grep loop
testfs on /root/blk/results/tmpdir.loop.011.t7M/tmpfs type tmpfs (rw,relatime,seclabel,inode64)