### PR TITLE
nvme/064: fix failure when the sysfs metadata_bytes doesn't exists

### DIFF
--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -154,7 +154,7 @@ _require_test_dev_is_not_nvme_multipath() {
 }
 
 _test_dev_has_metadata() {
-	if (( ! $(<"${TEST_DEV_SYSFS}/metadata_bytes") )); then
+	if [ ! -e "${TEST_DEV_SYSFS}/metadata_bytes" ] || (( ! $(<"${TEST_DEV_SYSFS}/metadata_bytes") )); then
 		SKIP_REASONS+=("$TEST_DEV does not have metadata")
 		return 1
 	fi


### PR DESCRIPTION
$ ./check nvme/064
tests/nvme/rc: line 157: /sys/devices/pci0000:40/0000:40:01.1/0000:41:00.0/nvme/nvme0/nvme0n1/metadata_bytes: No such file or directory tests/nvme/rc: line 157: ((: !  : syntax error: operand expected (error token is "!  ") nvme/064 => nvme0n1 (exercise the nvme metadata usage with passthrough commands) [not run]
    /dev/nvme0n1 enables NVME_NS_FLBAS_META_EXT
tests/nvme/rc: line 157: /sys/devices/pci0000:40/0000:40:03.3/0000:44:00.0/nvme/nvme2/nvme2n1/metadata_bytes: No such file or directory tests/nvme/rc: line 157: ((: !  : syntax error: operand expected (error token is "!  ") nvme/064 => nvme2n1 (exercise the nvme metadata usage with passthrough commands) [failed]
    runtime  0.001s  ...  0.001s
    --- tests/nvme/064.out	2025-06-26 05:06:53.764523070 -0400
    +++ /root/blktests/results/nvme2n1/nvme/064.out.bad	2025-06-26 22:43:12.911113037 -0400
    @@ -1,2 +1,4 @@
     Running nvme/064
    +Device format does not have metadata
    +src/nvme-passthrough-meta failed
     Test complete