### PR TITLE
block/017: wait device ready in _configure_null_blk

### DIFF
--- a/common/null_blk
+++ b/common/null_blk
@@ -73,6 +73,7 @@ _configure_null_blk() {
 			return 1
 		fi
 	done
+	udevadm settle
 }
 
 _exit_null_blk() {


### PR DESCRIPTION
This case might fail when run two or more times, it is quirky with load/unload null_blk in high frequency.
The patch wait for device ready before testing it.

Without this patch
```
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [passed]
    runtime  1.675s  ...  1.319s
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [failed]
    runtime  1.319s  ...  1.690s
    --- tests/block/017.out	2025-07-09 03:18:56.000000000 +0000
    +++ /usr/local/blktests/results/nodev/block/017.out.bad	2025-07-10 14:57:21.909726917 +0000
    @@ -4,9 +4,9 @@
     sysfs stat 1
     diskstats 1
     sysfs inflight reads 1
    -sysfs inflight writes 1
    -sysfs stat 2
    -diskstats 2
    +sysfs inflight writes 0
    ...
    (Run 'diff -u tests/block/017.out /usr/local/blktests/results/nodev/block/017.out.bad' to see the entire diff)
```
After apply the patch:
```
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [passed]
    runtime  1.690s  ...  1.405s
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [passed]
    runtime  1.405s  ...  1.372s
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [passed]
    runtime  1.372s  ...  1.386s
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [passed]
    runtime  1.386s  ...  1.367s
#  ./check block/017
block/017 (do I/O and check the inflight counter)            [passed]
    runtime  1.367s  ...  1.368s
```