### PR TITLE
loop/006: fix the test failure with Bash 5.3

### DIFF
--- a/tests/loop/006
+++ b/tests/loop/006
@@ -56,8 +56,9 @@ test() {
 	# Discard KILLED messages from bash...
 	{
 		kill -9 $switch_pid
+		wait $switch_pid
 		kill -9 $set_pid
-		wait
+		wait $set_pid
 		sleep 1
 	} 2>/dev/null
 


### PR DESCRIPTION
$ ./check loop/006
loop/006 (change loop backing file while creating/removing another loop device) [failed]
    runtime  31.526s  ...  31.036s
    --- tests/loop/006.out	2025-07-15 06:27:41.485609277 -0400
    +++ /root/blktests/results/nodev/loop/006.out.bad	2025-07-18 06:59:18.916498155 -0400
    @@ -1,2 +1,3 @@
     Running loop/006
    +tests/loop/006: line 66: 700070 Killed                     run_setter "$loop_dev"
     Test complete

Link: https://github.com/linux-blktests/blktests/issues/191