### PR TITLE
dm/003: fix readonly variable conflict by renaming TO_SKIP to SKIP_VAL

### DIFF
--- a/tests/dm/003
+++ b/tests/dm/003
@@ -15,7 +15,7 @@ requires() {
 	_have_scsi_debug
 }
 
-readonly TO_SKIP=255
+readonly SKIP_VAL=255
 
 setup_test_device() {
 	local dev blk_sz dpath
@@ -26,7 +26,7 @@ setup_test_device() {
 
 	if [[ ! -f /sys/block/${SCSI_DEBUG_DEVICES[0]}/queue/write_zeroes_unmap_max_hw_bytes ]]; then
 		_exit_scsi_debug
-		return $TO_SKIP
+		return $SKIP_VAL
 	fi
 
 	dev="/dev/${SCSI_DEBUG_DEVICES[0]}"
@@ -50,7 +50,7 @@ test() {
 	dname=$(setup_test_device lbprz=0)
 	ret=$?
 	if ((ret)); then
-		if ((ret == TO_SKIP)); then
+		if ((ret == SKIP_VAL)); then
 			SKIP_REASONS+=("kernel does not support unmap write zeroes sysfs interface")
 		fi
 		return 1


### PR DESCRIPTION
The TO_SKIP variable was declared as readonly but conflicts with an existing readonly variable in nvme/065, causing "readonly variable" errors when running tests in certain orders. Rename TO_SKIP to SKIP_VAL to avoid the naming conflict.

$ ./check dm/003 nvme/065
tests/nvme/065: line 23: TO_SKIP: readonly variable 
dm/003 (test unmap write zeroes sysfs interface with dm devices) [passed]
    runtime  5.790s  ...  5.839s
nvme/065 (test unmap write zeroes sysfs interface with nvmet devices) [passed]
    runtime  9.534s  ...  9.619s
$ ./check nvme/065 dm/003
tests/dm/003: line 18: TO_SKIP: readonly variable
dm/003 (test unmap write zeroes sysfs interface with dm devices) [passed]
    runtime  5.839s  ...  5.728s
nvme/065 (test unmap write zeroes sysfs interface with nvmet devices) [passed]
    runtime  9.619s  ...  9.546s