### PR TITLE
nvme: Fix fio process termination on completion

### DIFF
--- a/tests/nvme/032
+++ b/tests/nvme/032
@@ -30,6 +30,7 @@ device_requires() {
 test_device() {
 	echo "Running ${TEST_NAME}"
 
+	local fio_pid
 	local sysfs
 	local attr
 	local m
@@ -38,8 +39,11 @@ test_device() {
 	sysfs="/sys/bus/pci/devices/${pdev}"
 
 	# start fio job
+	set -m
 	_run_fio_rand_io --filename="$TEST_DEV" \
 		--group_reporting --time_based --runtime=1d &> /dev/null &
+	set +m
+	fio_pid=$!
 
 	sleep 5
 
@@ -54,7 +58,7 @@ test_device() {
 		fi
 	done
 
-	{ kill $!; wait; } &> /dev/null
+	{ kill -- -"${fio_pid}"; wait; } &> /dev/null
 
 	echo 1 > /sys/bus/pci/rescan
 

--- a/tests/nvme/040
+++ b/tests/nvme/040
@@ -37,9 +37,11 @@ test() {
 
 	# start fio job
 	echo "starting background fio"
+	set -m
 	_run_fio_rand_io --filename="/dev/${ns}" \
 		--group_reporting --ramp_time=5 \
 		--time_based --runtime=1d &> /dev/null &
+	set +m
 	fio_pid=$!
 	sleep 5
 
@@ -50,7 +52,7 @@ test() {
 	echo "deleting controller"
 	_nvme_delete_ctrl "${nvmedev}"
 
-	{ kill "${fio_pid}"; wait; } &> /dev/null
+	{ kill -- -"${fio_pid}"; wait; } &> /dev/null
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/057
+++ b/tests/nvme/057
@@ -70,9 +70,11 @@ test() {
 
 	# start fio job
 	ns=$(_find_nvme_ns "$def_subsys_uuid")
+	set -m
 	_run_fio_verify_io --filename="/dev/${ns}" \
 			   --group_reporting --ramp_time=5 \
 			   --time_based --runtime=1m &> "$FULL" &
+	set +m
 	fio_pid=$!
 	sleep 5
 
@@ -88,7 +90,7 @@ test() {
 
 	sleep 10
 
-	{ kill "${fio_pid}"; wait; } &> /dev/null
+	{ kill -- -"${fio_pid}"; wait; } &> /dev/null
 
 	_nvme_disconnect_subsys
 	_nvmet_target_cleanup

--- a/tests/nvme/061
+++ b/tests/nvme/061
@@ -34,9 +34,11 @@ test() {
 
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 
+	set -m
 	_run_fio_rand_io --filename="/dev/${ns}" \
 		--group_reporting \
 		--time_based --runtime=1d &> /dev/null &
+	set +m
 	fio_pid=$!
 	sleep 1
 
@@ -56,7 +58,7 @@ test() {
 		echo "state: $(cat "${state_file}")"
 	done
 
-	{ kill "${fio_pid}"; wait; } &> /dev/null
+	{ kill -- -"${fio_pid}"; wait; } &> /dev/null
 
 	_nvme_disconnect_subsys
 


### PR DESCRIPTION
fio was spawned inside a function, killing the function PID does not kill the fio process. Use set -m to enable job control and kill the fio process proccess group instead of the function PID.