### PR TITLE
nvme: add support for nvme-cli 3.x commands

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -38,58 +38,160 @@ _nvme_def_file_path() {
 	echo "${TMPDIR}/img"
 }
 
-_nvme_kxchap_cmd_style() {
-	if [[ -z "${_nvme_kxchap_style:-}" ]]; then
-		if nvme keys gen-kxchap --nqn nvmf-test-subsys > /dev/null 2>&1; then
-			_nvme_kxchap_style="3"
-		elif nvme gen-dhchap-key --nqn nvmf-test-subsys > /dev/null 2>&1; then
-			_nvme_kxchap_style="2"
+_nvme_cli_detect_version() {
+	if [[ -z "${_nvme_cli_version:-}" ]]; then
+		local ver major
+
+		ver="$(nvme version 2> /dev/null | awk '/^nvme version/ {print $3}')"
+		major="${ver%%.*}"
+		if [[ "${major}" =~ ^[0-9]+$ ]] && ((major >= 3)); then
+			_nvme_cli_version="3"
 		else
-			_nvme_kxchap_style="none"
+			_nvme_cli_version="2"
 		fi
 	fi
 }
 
-_nvme_tls_cmd_style() {
-	if [[ -z "${_nvme_tls_style:-}" ]]; then
-		if nvme keys gen-tls --subsysnqn nvmf-test-subsys > /dev/null 2>&1; then
-			_nvme_tls_style="3"
-		elif nvme gen-tls-key --subsysnqn nvmf-test-subsys > /dev/null 2>&1; then
-			_nvme_tls_style="2"
-		else
-			_nvme_tls_style="none"
-		fi
+declare -Ag _NVME_CMD_MAP=(
+	["keys gen-kxchap-secret"]="gen-dhchap-key"
+	["keys check-kxchap-secret"]="check-dhchap-key"
+	["keys gen-tls-psk"]="gen-tls-key"
+	["keys check-tls-psk"]="check-tls-key"
+
+	# log plugin
+	["log supported-pages"]="supported-log-pages"
+	["log telemetry"]="telemetry-log"
+	["log fw"]="fw-log"
+	["log changed-ns-list"]="changed-ns-list-log"
+	["log smart"]="smart-log"
+	["log ana"]="ana-log"
+	["log error"]="error-log"
+	["log effects"]="effects-log"
+	["log endurance"]="endurance-log"
+	["log predictable-lat"]="predictable-lat-log"
+	["log pred-lat-event-agg"]="pred-lat-event-agg-log"
+	["log persistent-event"]="persistent-event-log"
+	["log endurance-event-agg"]="endurance-event-agg-log"
+	["log lba-status"]="lba-status-log"
+	["log resv-notif"]="resv-notif-log"
+	["log boot-part"]="boot-part-log"
+	["log phy-rx-eom"]="phy-rx-eom-log"
+	["log self-test"]="self-test-log"
+	["log fid-support-effects"]="fid-support-effects-log"
+	["log mi-cmd-support-effects"]="mi-cmd-support-effects-log"
+	["log media-unit-stat"]="media-unit-stat-log"
+	["log supported-cap-config"]="supported-cap-config-log"
+	["log mgmt-addr-list"]="mgmt-addr-list-log"
+	["log rotational-media-info"]="rotational-media-info-log"
+	["log changed-alloc-ns-list"]="changed-alloc-ns-list-log"
+	["log dispersed-ns-participating-nss"]="dispersed-ns-participating-nss-log"
+	["log reachability-groups"]="reachability-groups-log"
+	["log reachability-associations"]="reachability-associations-log"
+	["log host-discovery"]="host-discovery-log"
+	["log ave-discovery"]="ave-discovery-log"
+	["log pull-model-ddc-req"]="pull-model-ddc-req-log"
+	["log power-measurement"]="power-measurement-log"
+	["log sanitize"]="sanitize-log"
+
+	# id plugin
+	["id ctrl"]="id-ctrl"
+	["id ns"]="id-ns"
+	["id ns-granularity"]="id-ns-granularity"
+	["id ns-lba-format"]="id-ns-lba-format"
+	["id ns-list"]="list-ns"
+	["id ctrl-list"]="list-ctrl"
+	["id nvm-ctrl"]="nvm-id-ctrl"
+	["id nvm-ns"]="nvm-id-ns"
+	["id nvm-ns-lba-format"]="nvm-id-ns-lba-format"
+	["id primary-ctrl-caps"]="primary-ctrl-caps"
+	["id secondary-ctrl-list"]="list-secondary"
+	["id ns-ind"]="cmdset-ind-id-ns"
+	["id ns-descs"]="ns-descs"
+	["id nvmset"]="id-nvmset"
+	["id uuid"]="id-uuid"
+	["id iocs"]="id-iocs"
+	["id domain"]="id-domain"
+	["id endgrp-list"]="list-endgrp"
+
+	# ns plugin
+	["ns create"]="create-ns"
+	["ns delete"]="delete-ns"
+	["ns attach"]="attach-ns"
+	["ns detach"]="detach-ns"
+	["ns get-id"]="get-ns-id"
+
+	# resv plugin
+	["resv acquire"]="resv-acquire"
+	["resv register"]="resv-register"
+	["resv release"]="resv-release"
+	["resv report"]="resv-report"
+
+	# nvme-mi plugin
+	["nvme-mi recv"]="nvme-mi-recv"
+	["nvme-mi send"]="nvme-mi-send"
+
+	# io-mgmt plugin
+	["io-mgmt recv"]="io-mgmt-recv"
+	["io-mgmt send"]="io-mgmt-send"
+
+	# dir plugin
+	["dir receive"]="dir-receive"
+	["dir send"]="dir-send"
+
+	# security plugin
+	["security send"]="security-send"
+	["security recv"]="security-recv"
+
+	# fw plugin
+	["fw commit"]="fw-commit"
+	["fw download"]="fw-download"
+)
+
+_nvme_cmd() {
+	_nvme_cli_detect_version
+	if [[ "${_nvme_cli_version}" == "3" ]]; then
+		echo "$1"
+	else
+		echo "${_NVME_CMD_MAP[$1]}"
 	fi
 }
 
-_nvme_gen_kxchap_key() {
-	_nvme_kxchap_cmd_style
-	case "$_nvme_kxchap_style" in
-	3)
-		nvme keys gen-kxchap "$@"
-		;;
-	2)
-		nvme gen-dhchap-key "$@"
-		;;
-	*)
-		return 1
-		;;
-	esac
+# Run "nvme <resolved subcommand> $@" for a current (>=3.0) top-level
+# command name, e.g. `_nvme_run "id ctrl" "$dev"` runs
+# `nvme id ctrl "$dev"` on >=3.0 or `nvme id-ctrl "$dev"` on 2.x.
+_nvme_run() {
+	local current=$1
+	shift
+
+	# shellcheck disable=SC2046
+	nvme $(_nvme_cmd "$current") "$@"
 }
 
-_nvme_gen_tls_key() {
-	_nvme_tls_cmd_style
-	case "$_nvme_tls_style" in
-	3)
-		nvme keys gen-tls "$@"
-		;;
-	2)
-		nvme gen-tls-key "$@"
-		;;
-	*)
-		return 1
-		;;
-	esac
+_nvme_gen_kxchap_secret() {
+	_nvme_cli_detect_version
+
+	if [[ "${_nvme_cli_version}" == "3" ]]; then
+		local -a kxchap_args=()
+
+		while (($#)); do
+			case "$1" in
+			--key-length=*)
+				kxchap_args+=("--secret-length=${1#--key-length=}")
+				;;
+			--key-length)
+				kxchap_args+=("--secret-length" "$2")
+				shift
+				;;
+			*)
+				kxchap_args+=("$1")
+				;;
+			esac
+			shift
+		done
+		set -- "${kxchap_args[@]}"
+	fi
+
+	_nvme_run "keys gen-kxchap-secret" "$@"
 }
 
 _require_nvme_trtype() {
@@ -1441,7 +1543,7 @@ _test_dev_has_no_metadata() {
 _test_dev_disables_extended_lba() {
 	local flbas
 
-	if ! _test_dev_is_nvme || ! flbas=$(nvme id-ns "$TEST_DEV" | \
+	if ! _test_dev_is_nvme || ! flbas=$(_nvme_run "id ns" "$TEST_DEV" | \
 	   grep flbas | sed --quiet 's/.*: \(.*\)/\1/p'); then
 		SKIP_REASONS+=("$TEST_DEV does not have namespace flbas field")
 		return 1
@@ -1468,6 +1570,7 @@ _require_nvme_test_img_size() {
 }
 
 _nvme_requires() {
+	_nvme_cli_detect_version
 	_require_nvme_test_img_size 4m
 	case ${nvme_trtype} in
 	loop)

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -32,7 +32,7 @@ test() {
 
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 
-	if ! nvme smart-log "/dev/${ns}" >> "$FULL" 2>&1; then
+	if ! _nvme_run "log smart" "/dev/${ns}" >> "$FULL" 2>&1; then
 		echo "ERROR: smart-log bdev-ns failed"
 	fi
 

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -32,7 +32,7 @@ test() {
 
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 
-	if ! nvme ns-descs "/dev/${ns}" >> "$FULL" 2>&1; then
+	if ! _nvme_run "id ns-descs" "/dev/${ns}" >> "$FULL" 2>&1; then
 		echo "ERROR: ns-desc failed"
 	fi
 

--- a/tests/nvme/033
+++ b/tests/nvme/033
@@ -25,8 +25,8 @@ set_conditions() {
 nvme_info() {
 	local ns=$1
 
-	nvme id-ctrl "${ns}" | grep -E '^(vid|sn|mn|fr) '
-	nvme id-ns "${ns}" | grep -E '^(nsze|ncap) '
+	_nvme_run "id ctrl" "${ns}" | grep -E '^(vid|sn|mn|fr) '
+	_nvme_run "id ns" "${ns}" | grep -E '^(nsze|ncap) '
 }
 
 compare_dev_info() {

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -30,7 +30,7 @@ test() {
 	local hostkey
 	local ctrldev
 
-	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "key generation failed"
 		return 1

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -36,7 +36,7 @@ test() {
 
 	for hmac in 0 1 2 3; do
 		echo "Testing hmac ${hmac}"
-		hostkey="$(_nvme_gen_kxchap_key --hmac=${hmac} --nqn "${def_subsysnqn}" 2> /dev/null)"
+		hostkey="$(_nvme_gen_kxchap_secret --hmac=${hmac} 2> /dev/null)"
 		if [ -z "$hostkey" ] ; then
 			echo "couldn't generate host key for hmac ${hmac}"
 			return 1
@@ -50,7 +50,7 @@ test() {
 
 	for key_len in 32 48 64; do
 		echo "Testing key length ${key_len}"
-		hostkey="$(_nvme_gen_kxchap_key --key-length=${key_len} --nqn "${def_subsysnqn}" 2> /dev/null)"
+		hostkey="$(_nvme_gen_kxchap_secret --key-length=${key_len} 2> /dev/null)"
 		if [ -z "$hostkey" ] ; then
 			echo "couldn't generate host key for length ${key_len}"
 			return 1

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -33,7 +33,7 @@ test() {
 	local hostkey
 	local ctrldev
 
-	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_hostnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "key generation failed"
 		return 1

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -32,13 +32,13 @@ test() {
 	local ctrlkey
 	local ctrldev
 
-	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	ctrlkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -37,13 +37,13 @@ test() {
 	local rand_io_size
 	local ns
 
-	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	ctrlkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1
@@ -68,7 +68,7 @@ test() {
 
 	echo "Renew host key on the controller"
 
-	new_hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	new_hostkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 
 	_set_nvmet_hostkey "${def_hostnqn}" "${new_hostkey}"
 
@@ -78,7 +78,7 @@ test() {
 
 	echo "Renew ctrl key on the controller"
 
-	new_ctrlkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	new_ctrlkey="$(_nvme_gen_kxchap_secret 2> /dev/null)"
 
 	_set_nvmet_ctrlkey "${def_hostnqn}" "${new_ctrlkey}"
 

--- a/tests/nvme/046
+++ b/tests/nvme/046
@@ -36,15 +36,15 @@ test_device() {
 		echo "Error: io-passthru write passed (unexpected)"
 	fi
 
-	if ! _run_user "nvme id-ns ${ngdev}" >> "${FULL}" 2>&1; then
+	if ! _run_user "nvme $(_nvme_cmd "id ns") ${ngdev}" >> "${FULL}" 2>&1; then
 		echo "Error: id-ns failed"
 	fi
 
-	if ! _run_user "nvme id-ctrl ${ngdev}" >> "${FULL}" 2>&1; then
+	if ! _run_user "nvme $(_nvme_cmd "id ctrl") ${ngdev}" >> "${FULL}" 2>&1; then
 		echo "Error: id-ctrl failed"
 	fi
 
-	if _run_user "nvme ns-descs ${ngdev}" >> "${FULL}" 2>&1; then
+	if _run_user "nvme $(_nvme_cmd "id ns-descs") ${ngdev}" >> "${FULL}" 2>&1; then
 		echo "Error: ns-descs passed (unexpected)"
 	fi
 

--- a/tests/nvme/054
+++ b/tests/nvme/054
@@ -23,7 +23,7 @@ resv_report() {
 	local test_dev=$1
 	local report_arg=$2
 
-	nvme resv-report "${test_dev}" "${report_arg}" | grep -v "hostid" | \
+	_nvme_run "resv report" "${test_dev}" "${report_arg}" | grep -v "hostid" | \
 		grep -E "gen|rtype|regctl|regctlext|cntlid|rcsts|rkey"
 }
 
@@ -31,7 +31,7 @@ nvme_resv() {
 	local cmd=$1
 	local test_dev=$2
 	shift 2
-	if ! nvme resv-"${cmd}" "$test_dev" "$@" >>"${FULL}" 2>&1; then
+	if ! _nvme_run "resv ${cmd}" "$test_dev" "$@" >>"${FULL}" 2>&1; then
 		echo "FAIL: nvme resv-${cmd} failed on $test_dev with args: $*"
 		return 1
 	fi
@@ -42,7 +42,7 @@ test_resv() {
 	local report_arg="--cdw11=1"
 	local test_dev="/dev/${ns}"
 
-	if nvme resv-report --help 2>&1 | grep -- '--eds' > /dev/null; then
+	if _nvme_run "resv report" --help 2>&1 | grep -- '--eds' > /dev/null; then
 		report_arg="--eds"
 	fi
 

--- a/tests/nvme/054
+++ b/tests/nvme/054
@@ -23,8 +23,73 @@ resv_report() {
 	local test_dev=$1
 	local report_arg=$2
 
-	_nvme_run "resv report" "${test_dev}" "${report_arg}" | grep -v "hostid" | \
-		grep -E "gen|rtype|regctl|regctlext|cntlid|rcsts|rkey"
+	_nvme_run "resv report" "${test_dev}" "${report_arg}"
+}
+
+# Return the value of a scalar reservation status field out of a "nvme resv
+# report" text report. Accepts up to two names for the field: nvme-cli renamed
+# several of them after NVMe Base Specification 2.4 (ECN132), e.g. from
+# "regctl" to "regstrnt".
+resv_field() {
+	local report=$1
+	local field=$2
+	local alt_field=${3:-$2}
+
+	echo "${report}" | \
+		sed -n -E "s/^(${field}|${alt_field})[[:space:]]*:[[:space:]]*//p" | \
+		head -1
+}
+
+# Return the Nth (0-based) occurrence of an indented per-registrant
+# field (cntlid, rcsts, or rkey) out of a "nvme resv report" text
+# report.
+resv_registrant_field() {
+	local report=$1
+	local idx=$2
+	local field=$3
+
+	echo "${report}" | \
+		sed -n -E "s/^[[:space:]]+${field}[[:space:]]*:[[:space:]]*//p" | \
+		sed -n "$((idx + 1))p"
+}
+
+check_resv_status() {
+	local report=$1
+	local exp_gen=$2
+	local exp_rtype=$3
+	local exp_count=$4
+	local gen rtype count
+
+	gen=$(resv_field "${report}" gen)
+	rtype=$(resv_field "${report}" rtype)
+	count=$(resv_field "${report}" regctl regstrnt)
+
+	[[ "${gen}" == "${exp_gen}" ]] || \
+		echo "FAIL: expected gen ${exp_gen}, got '${gen}'"
+	[[ "${rtype}" == "${exp_rtype}" ]] || \
+		echo "FAIL: expected rtype ${exp_rtype}, got '${rtype}'"
+	[[ "${count}" == "${exp_count}" ]] || \
+		echo "FAIL: expected regctl/regstrnt ${exp_count}, got '${count}'"
+}
+
+check_resv_registrant() {
+	local report=$1
+	local idx=$2
+	local exp_cntlid=$3
+	local exp_rcsts=$4
+	local exp_rkey=$5
+	local cntlid rcsts rkey
+
+	cntlid=$(resv_registrant_field "${report}" "${idx}" cntlid)
+	rcsts=$(resv_registrant_field "${report}" "${idx}" rcsts)
+	rkey=$(resv_registrant_field "${report}" "${idx}" rkey)
+
+	[[ "${cntlid}" == "${exp_cntlid}" ]] || \
+		echo "FAIL: expected registrant[${idx}] cntlid ${exp_cntlid}, got '${cntlid}'"
+	[[ "${rcsts}" == "${exp_rcsts}" ]] || \
+		echo "FAIL: expected registrant[${idx}] rcsts ${exp_rcsts}, got '${rcsts}'"
+	[[ "${rkey}" == "${exp_rkey}" ]] || \
+		echo "FAIL: expected registrant[${idx}] rkey ${exp_rkey}, got '${rkey}'"
 }
 
 nvme_resv() {
@@ -41,40 +106,55 @@ test_resv() {
 	local ns=$1
 	local report_arg="--cdw11=1"
 	local test_dev="/dev/${ns}"
+	local report
 
 	if _nvme_run "resv report" --help 2>&1 | grep -- '--eds' > /dev/null; then
 		report_arg="--eds"
 	fi
 
 	echo "Register"
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 0 0 0
 	nvme_resv register "${test_dev}" --nrkey=4 --rrega=0
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 1 0 1
+	check_resv_registrant "${report}" 0 ffff 0 4
 
 	echo "Replace"
 	nvme_resv register "${test_dev}" --crkey=4 --nrkey=5 --rrega=2
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 2 0 1
+	check_resv_registrant "${report}" 0 ffff 0 5
 
 	echo "Unregister"
 	nvme_resv register "${test_dev}" --crkey=5 --rrega=1
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 3 0 0
 
 	echo "Acquire"
 	nvme_resv register "${test_dev}" --nrkey=4 --rrega=0
 	nvme_resv acquire "${test_dev}" --crkey=4 --rtype=1 --racqa=0
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 4 1 1
+	check_resv_registrant "${report}" 0 ffff 1 4
 
 	echo "Preempt"
 	nvme_resv acquire "${test_dev}" --crkey=4 --prkey=4 --rtype=2 --racqa=1
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 5 2 1
+	check_resv_registrant "${report}" 0 ffff 1 4
 
 	echo "Release"
 	nvme_resv release "${test_dev}" --crkey=4 --rtype=2 --rrela=0
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 5 0 1
+	check_resv_registrant "${report}" 0 ffff 0 4
 
 	echo "Clear"
 	nvme_resv acquire "${test_dev}" --crkey=4 --rtype=1 --racqa=0
-	resv_report "${test_dev}" "${report_arg}"
+	report=$(resv_report "${test_dev}" "${report_arg}")
+	check_resv_status "${report}" 5 1 1
+	check_resv_registrant "${report}" 0 ffff 1 4
 	nvme_resv release "${test_dev}" --crkey=4 --rrela=1
 }
 

--- a/tests/nvme/054.out
+++ b/tests/nvme/054.out
@@ -1,57 +1,9 @@
 Running nvme/054
 Register
-gen       : 0
-rtype     : 0
-regctl    : 0
-gen       : 1
-rtype     : 0
-regctl    : 1
-regctlext[0] :
-  cntlid     : ffff
-  rcsts      : 0
-  rkey       : 4
 Replace
-gen       : 2
-rtype     : 0
-regctl    : 1
-regctlext[0] :
-  cntlid     : ffff
-  rcsts      : 0
-  rkey       : 5
 Unregister
-gen       : 3
-rtype     : 0
-regctl    : 0
 Acquire
-gen       : 4
-rtype     : 1
-regctl    : 1
-regctlext[0] :
-  cntlid     : ffff
-  rcsts      : 1
-  rkey       : 4
 Preempt
-gen       : 5
-rtype     : 2
-regctl    : 1
-regctlext[0] :
-  cntlid     : ffff
-  rcsts      : 1
-  rkey       : 4
 Release
-gen       : 5
-rtype     : 0
-regctl    : 1
-regctlext[0] :
-  cntlid     : ffff
-  rcsts      : 0
-  rkey       : 4
 Clear
-gen       : 5
-rtype     : 1
-regctl    : 1
-regctlext[0] :
-  cntlid     : ffff
-  rcsts      : 1
-  rkey       : 4
 Test complete

--- a/tests/nvme/059
+++ b/tests/nvme/059
@@ -65,14 +65,14 @@ test_device() {
 
 	test_desc="TEST 2 - Verify sysfs atomic_write_unit_max_bytes is consistent "
 	test_desc+="with NVMe AWUPF/NAWUPF"
-	nvme_nsfeat=$(nvme id-ns /dev/"${ns_dev}" | grep nsfeat | awk '{ print $3}')
+	nvme_nsfeat=$(_nvme_run "id ns" /dev/"${ns_dev}" | grep nsfeat | awk '{ print $3}')
 	nvme_nsabp=$((("$nvme_nsfeat" & 0x2) != 0))
 	if [ "$nvme_nsabp" = 1 ] # Check if NSABP is set
 	then
-		nvme_awupf=$(nvme id-ns /dev/"$ns_dev" | grep nawupf | awk '{ print $3}')
+		nvme_awupf=$(_nvme_run "id ns" /dev/"$ns_dev" | grep nawupf | awk '{ print $3}')
 		atomic_max_bytes=$(( ("$nvme_awupf" + 1) * "$sysfs_logical_block_size" ))
 	else
-		nvme_awupf=$(nvme id-ctrl /dev/"${ctrl_dev}" | grep awupf | awk '{ print $3}')
+		nvme_awupf=$(_nvme_run "id ctrl" /dev/"${ctrl_dev}" | grep awupf | awk '{ print $3}')
 		atomic_max_bytes=$(( ("$nvme_awupf" + 1) * "$sysfs_logical_block_size" ))
 	fi
 	if [ "$atomic_max_bytes" -le "$max_hw_bytes" ]

--- a/tests/nvme/062
+++ b/tests/nvme/062
@@ -32,7 +32,7 @@ test() {
 	local hostkey
 	local ctrl
 
-	hostkey=$(_nvme_gen_tls_key -n "${def_hostnqn}" -c "${def_subsysnqn}" -m 1 -I 1 -i 2> /dev/null)
+	hostkey=$(_nvme_run "keys gen-tls-psk" -n "${def_hostnqn}" -c "${def_subsysnqn}" -m 1 -I 1 -i 2> /dev/null)
 	if [ -z "$hostkey" ] ; then
 		echo "TLS key generation failed"
 		return 1

--- a/tests/nvme/063
+++ b/tests/nvme/063
@@ -34,7 +34,7 @@ test() {
 
 	_systemctl_start tlshd
 
-	hostkey=$(_nvme_gen_kxchap_key --hmac 1 --nqn "${def_hostnqn}" 2> /dev/null)
+	hostkey=$(_nvme_gen_kxchap_secret --hmac 1 2> /dev/null)
 	if [ -z "$hostkey" ] ; then
 		echo "key generation failed"
 		_systemctl_stop
@@ -76,7 +76,7 @@ test() {
 
 	_nvme_disconnect_subsys
 
-	hostkey=$(_nvme_gen_kxchap_key --hmac 2 --nqn "${def_hostnqn}" 2> /dev/null)
+	hostkey=$(_nvme_gen_kxchap_secret --hmac 2 2> /dev/null)
 	if [ -z "$hostkey" ] ; then
 		echo "key generation failed"
 		_systemctl_stop

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -100,18 +100,16 @@ _require_test_dev_support_sed() {
 }
 
 _require_nvme_cli_auth() {
-	_nvme_kxchap_cmd_style
-	if [[ "$_nvme_kxchap_style" == "none" ]]; then
-		SKIP_REASONS+=("nvme gen-dhchap-key / nvme keys gen-kxchap command missing")
+	if ! _nvme_gen_kxchap_secret > /dev/null 2>&1; then
+		SKIP_REASONS+=("nvme gen-dhchap-key / nvme keys gen-kxchap-secret command missing")
 		return 1
 	fi
 	return 0
 }
 
 _require_nvme_cli_tls() {
-	_nvme_tls_cmd_style
-	if [[ "$_nvme_tls_style" == "none" ]]; then
-		SKIP_REASONS+=("nvme gen-tls-key / nvme keys gen-tls command missing")
+	if ! _nvme_run "keys gen-tls-psk" --subsysnqn nvmf-test-subsys > /dev/null 2>&1; then
+		SKIP_REASONS+=("nvme gen-tls-key / nvme keys gen-tls-psk command missing")
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
nvme-cli 3.x grouped commands into plugins, such as all log
commands. The CLI supports the old commands via a trampoline command
implementation, but warns the user by writing an informational message
to stderr, which will cause many of the nvme tests to fail.

Add an indirection layer for nvme-cli commands that maps the new command
pattern to the old one, so support for nvme-cli 2.x can be dropped in
the future.

