### PR TITLE
Fix silent failures in scsi_debug zbc setup and block/035, fix meta/022 typo

### DIFF
--- a/common/scsi_debug
+++ b/common/scsi_debug
@@ -116,7 +116,7 @@ _init_scsi_debug() {
 
 	if (( RUN_FOR_ZONED )); then
 		if ! _have_module_param scsi_debug zbc; then
-			return
+			return 1
 		fi
 		args+=(zbc=host-managed zone_nr_conv=0)
 	fi

--- a/tests/block/035
+++ b/tests/block/035
@@ -74,9 +74,9 @@ test() {
 	# reset io_uring setting before exits test
 	_io_uring_restore
 
-	if [ $fio_status != 0 ]; then
+	if [ "$fio_status" -ne 0 ]; then
 		echo "Failed (fio status = $fio_status)"
-		return
+		return 1
 	fi
 	local iops1 iops2 rest
 	read -r iops1 iops2 rest \

--- a/tests/meta/022
+++ b/tests/meta/022
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2025 Western Digital Corporation or its affiliates.
 #
-# Test skip in device_requries() for test_device_array()
+# Test skip in device_requires() for test_device_array()
 
 . tests/meta/rc
 
-DESCRIPTION="skip test_device_array() in device_requries()"
+DESCRIPTION="skip test_device_array() in device_requires()"
 
 device_requires() {
 	SKIP_REASONS+=("(╯°□°)╯︵ $TEST_DEV ┻━┻")


### PR DESCRIPTION
Three small fixes found while reviewing the tree:

**1. common/scsi_debug: return failure when zbc module parameter is missing**

The `_init_scsi_debug()` zbc probe path ends with a bare `return` inside
`if ! _have_module_param scsi_debug zbc; then ... fi`. That propagates the
negated test's exit status (0), so the function reports success even though
no module was loaded and no devices were created. Tests then fail later with
a confusing output mismatch instead of a clean "not run". With the return
value fixed, the `SKIP_REASON` recorded by `_have_module_param()` is reported
properly by the runner.

**2. block/035: return failure on fio error**

On fio failure the test prints "Failed ..." and does a bare `return`, which
propagates echo's exit status (0) — the test reports success and only the
`.out` diff catches it, with the recorded reason being misleading. Also quote
the `$fio_status` comparison, matching the style used elsewhere in the file.

**3. meta/022: fix device_requires typo in header and description**

Validation: `bash -n`, shellcheck (with the tree's SC2119 exception), and
full-tree `make check` are all clean.