### PR TITLE
check: avoid dmesg marker collisions

### DIFF
--- a/check
+++ b/check
@@ -449,9 +449,11 @@ _call_test() {
 	declare -A LAST_TEST_RUN
 	_read_last_test_run
 	_output_last_test_run
+	local test_start
+	test_start="$(date "+%F %T.%N")"
 
 	declare -A TEST_RUN
-	TEST_RUN["date"]="$(date "+%F %T")"
+	TEST_RUN["date"]="${test_start%.*}"
 	TEST_RUN["description"]="${DESCRIPTION}"
 
 	mkdir -p "$(dirname "$seqres")"
@@ -464,7 +466,7 @@ _call_test() {
 		_setup_kmemleak
 
 		if [[ -w /dev/kmsg ]]; then
-			local dmesg_marker="run blktests $TEST_NAME at ${TEST_RUN["date"]}"
+			local dmesg_marker="run blktests $TEST_NAME at $test_start"
 			echo "$dmesg_marker" >> /dev/kmsg
 		else
 			local dmesg_marker=""


### PR DESCRIPTION
`loop/011` can fail when it is run twice within the same second because
both runs get the same dmesg marker.

In that case, `_dmesg_since_test_start()` also includes messages from the
previous run.

Use a higher-resolution timestamp for the dmesg marker while keeping the existing
`TEST_RUN["date"]` format.

Tested with 10 pairs of back-to-back `loop/011` runs and `make check`.

Fixes #231 